### PR TITLE
Rename AUX LED variables in code to match printed labels on board. 

### DIFF
--- a/src/Margay.cpp
+++ b/src/Margay.cpp
@@ -35,7 +35,7 @@ Margay::Margay(board model_, build specs_)
 {
 	if(model_ == 2) {
 		SD_CS = 4;
-		BuiltInLED = 20;
+		AuxLED = 20;
 		RedLED = 13;
 		GreenLED = 15;
 		BlueLED = 14;
@@ -78,7 +78,7 @@ Margay::Margay(board model_, build specs_)
 	}
 	else if(model_ == 1) {
 		SD_CS = 4;
-		BuiltInLED = 20;
+		AuxLED = 20;
 		RedLED = 13;
 		GreenLED = 15;
 		BlueLED = 14;
@@ -127,7 +127,7 @@ Margay::Margay(board model_, build specs_)
 	}
 	else {
 		SD_CS = 4;
-		BuiltInLED = 19;
+		AuxLED = 19;
 		RedLED = 13;
 		GreenLED = 15;
 		BlueLED = 14;
@@ -176,8 +176,8 @@ int Margay::begin(uint8_t *Vals, uint8_t numVals, String header_)
 	// pinMode(Ext3v3Ctrl, OUTPUT);
 	// digitalWrite(Ext3v3Ctrl, HIGH); //Make sure external power is on
 
-	pinMode(BuiltInLED, OUTPUT);
-	digitalWrite(BuiltInLED, LOW); //Turn built in LED on
+	pinMode(AuxLED, OUTPUT);
+	digitalWrite(AuxLED, LOW); //Turn built in LED on
 
 	pinMode(VSwitch_Pin, OUTPUT); //Setup switch control as output
 
@@ -275,14 +275,12 @@ int Margay::begin(uint8_t *Vals, uint8_t numVals, String header_)
 	batTest();
 	if(Model >= MODEL_2v0) enviroStats();  //Only print out enviromental variables if BME is on board
 
+	digitalWrite(AuxLED, HIGH);
 
-
-  	digitalWrite(BuiltInLED, HIGH);
-
-  	if(OBError) {
-  		LED_Color(RED);	//On board failure
-  		delay(2000);
-  	}
+	if(OBError) {
+		LED_Color(RED);	//On board failure
+		delay(2000);
+	}
 	if(SensorError) {
 		LED_Color(ORANGE);  //Sensor failure
 		delay(2000);
@@ -881,7 +879,7 @@ void Margay::_addDataPoint(String data)
 	digitalWrite(BlueLED, HIGH); //OFF
 	// Serial.println("Got OB Vals");  //DEBUG!
 	logStr(data);
-	// Serial.println("Loged Data"); //DEBUG!
+	// Serial.println("Logged Data"); //DEBUG!	
 }
 
 //ISRs

--- a/src/Margay.h
+++ b/src/Margay.h
@@ -73,7 +73,7 @@ class Margay
 
 	public:
 		Margay(board model_ = MODEL_2v2, build specs_ = BUILD_B);
-    int begin(uint8_t *Vals, uint8_t numVals, String header_);
+	    int begin(uint8_t *Vals, uint8_t numVals, String header_);
 		int begin(String header_ = "");
 
 		int logStr(String val);
@@ -98,7 +98,7 @@ class Margay
 
 		//Pin definitions
 		int SD_CS = 4;
-		uint8_t BuiltInLED = 20;
+		uint8_t AuxLED = 20;
 		uint8_t RedLED = 13;
 		uint8_t GreenLED = 15;
 		uint8_t BlueLED = 14;
@@ -133,7 +133,7 @@ class Margay
 		static void isr1();
 		static void isr2();
 		static Margay* selfPointer;
-    static void dateTimeSD(uint16_t* date, uint16_t* time);
+	    static void dateTimeSD(uint16_t* date, uint16_t* time);
 		void dateTimeSD_Glob(uint16_t* date, uint16_t* time);
 	    void switchExternalI2C(bool desiredState);
 		void sleepNow();


### PR DESCRIPTION
Aux LED in code was previously called Built-in LED. Rename in code to match silkscreen on board labels.

This PR also includes a few code indentation changes. 